### PR TITLE
feat: Add new team permissions and enhance CLI flag handling

### DIFF
--- a/client/client/team.go
+++ b/client/client/team.go
@@ -11,7 +11,7 @@ type TeamClient struct {
 }
 
 func (c *TeamClient) List(organizationId string, filter string) ([]*models.Team, error) {
-	req, err := c.Client.newRequest(http.MethodGet, fmt.Sprintf("organization/%v/team", organizationId), nil)
+	req, err := c.Client.newRequestWithFilter(http.MethodGet, fmt.Sprintf("organization/%v/team", organizationId), filter, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/models/team.go
+++ b/client/models/team.go
@@ -37,4 +37,16 @@ type TeamAttributes struct {
 
 	// manageProvider
 	ManageProvider bool `json:"manageProvider,omitempty"`
+
+	// manageState
+	ManageState bool `json:"manageState,omitempty"`
+
+	// manageCollection
+	ManageCollection bool `json:"manageCollection,omitempty"`
+
+	// manageVcs
+	ManageVcs bool `json:"manageVcs,omitempty"`
+
+	// manageTemplate
+	ManageTemplate bool `json:"manageTemplate,omitempty"`
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,7 +144,16 @@ func splitInterface(input interface{}) ([][]string, []string) {
 				if i == 0 {
 					headers = append(headers, attr.Type().Field(j).Name)
 				}
-				row = append(row, attr.Field(j).String())
+				fieldValue := attr.Field(j)
+				var valueStr string
+				switch fieldValue.Kind() {
+				case reflect.Bool:
+					valueStr = fmt.Sprintf("%t", fieldValue.Bool())
+				default:
+					valueStr = fieldValue.String()
+				}
+
+				row = append(row, valueStr)
 			}
 			result = append(result, row)
 		}
@@ -157,7 +166,15 @@ func splitInterface(input interface{}) ([][]string, []string) {
 		attr := reflect.Indirect(reflect.ValueOf(d.FieldByName("Attributes").Interface()))
 		for j := 0; j < attr.NumField(); j++ {
 			headers = append(headers, attr.Type().Field(j).Name)
-			row = append(row, attr.Field(j).String())
+			fieldValue := attr.Field(j)
+			var valueStr string
+			switch fieldValue.Kind() {
+			case reflect.Bool:
+				valueStr = fmt.Sprintf("%t", fieldValue.Bool())
+			default:
+				valueStr = fieldValue.String()
+			}
+			row = append(row, valueStr)
 		}
 		result = append(result, row)
 

--- a/cmd/team_create.go
+++ b/cmd/team_create.go
@@ -15,6 +15,10 @@ var TeamCreateOrgId string
 var TeamCreateManageProvider bool
 var TeamCreateManageModule bool
 var TeamCreateManageWorkspace bool
+var TeamCreateManageState bool
+var TeamCreateManageCollection bool
+var TeamCreateManageVcs bool
+var TeamCreateManageTemplate bool
 
 var createTeamCmd = &cobra.Command{
 	Use:   "create",
@@ -32,11 +36,12 @@ func init() {
 	createTeamCmd.Flags().StringVarP(&TeamCreateOrgId, "organization-id", "", "", "Organization Id (required)")
 	_ = createTeamCmd.MarkFlagRequired("organization-id")
 	createTeamCmd.Flags().BoolVarP(&TeamCreateManageProvider, "manage-provider", "", false, "Manage Provider Permissions")
-	_ = createTeamCmd.MarkFlagRequired("manage-provider")
 	createTeamCmd.Flags().BoolVarP(&TeamCreateManageModule, "manage-module", "", false, "Manage Module Permissions")
-	_ = createTeamCmd.MarkFlagRequired("manage-module")
 	createTeamCmd.Flags().BoolVarP(&TeamCreateManageWorkspace, "manage-workspace", "", false, "Manage Workspaces Permissions")
-	_ = createTeamCmd.MarkFlagRequired("manage-workspace")
+	createTeamCmd.Flags().BoolVarP(&TeamCreateManageState, "manage-state", "", false, "Manage State Permissions")
+	createTeamCmd.Flags().BoolVarP(&TeamCreateManageCollection, "manage-collection", "", false, "Manage Collection Permissions")
+	createTeamCmd.Flags().BoolVarP(&TeamCreateManageVcs, "manage-vcs", "", false, "Manage VCS Permissions")
+	createTeamCmd.Flags().BoolVarP(&TeamCreateManageTemplate, "manage-template", "", false, "Manage Template Permissions")
 
 }
 
@@ -45,10 +50,14 @@ func createTeam() {
 
 	team := models.Team{
 		Attributes: &models.TeamAttributes{
-			Name:            TeamCreateName,
-			ManageWorkspace: TeamCreateManageWorkspace,
-			ManageModule:    TeamCreateManageModule,
-			ManageProvider:  TeamCreateManageProvider,
+			Name:             TeamCreateName,
+			ManageWorkspace:  TeamCreateManageWorkspace,
+			ManageModule:     TeamCreateManageModule,
+			ManageProvider:   TeamCreateManageProvider,
+			ManageState:      TeamCreateManageState,
+			ManageCollection: TeamCreateManageCollection,
+			ManageVcs:        TeamCreateManageVcs,
+			ManageTemplate:   TeamCreateManageTemplate,
 		},
 		Type: "team",
 	}


### PR DESCRIPTION
This will allow to use the following:

```
terrakube team create --organization-id d9b58bd3-f3fc-4056-a026-1163297e80a8 --name test --manage-provider true
terrakube team list --organization-id d9b58bd3-f3fc-4056-a026-1163297e80a8 --output table --filter filter[team]=name==TERRAKUBE_DEVELOPERS
```

Added the missing fields:

- manage-provider
- manage-state
- manage-collecdtion
- manage-vcs
- 