### PR TITLE
feat: Add support for additional module attributes and team permissions

### DIFF
--- a/client/client/module.go
+++ b/client/client/module.go
@@ -1,9 +1,9 @@
 package client
 
 import (
-	"terrakube/client/models"
 	"fmt"
 	"net/http"
+	"terrakube/client/models"
 )
 
 type ModuleClient struct {
@@ -11,7 +11,7 @@ type ModuleClient struct {
 }
 
 func (c *ModuleClient) List(organizationId string, filter string) ([]*models.Module, error) {
-	req, err := c.Client.newRequest(http.MethodGet, fmt.Sprintf("organization/%v/module", organizationId), nil)
+	req, err := c.Client.newRequestWithFilter(http.MethodGet, fmt.Sprintf("organization/%v/module", organizationId), filter, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/models/module.go
+++ b/client/models/module.go
@@ -41,8 +41,11 @@ type ModuleAttributes struct {
 	// source
 	Source string `json:"source,omitempty"`
 
-	// sourceSample
-	SourceSample string `json:"sourceSample,omitempty"`
+	// tagprefix
+	TagPrefix *string `json:"tagPrefix,omitempty"`
+
+	// folder
+	Folder *string `json:"folder,omitempty"`
 
 	// registryPath
 	RegistryPath string `json:"registryPath,omitempty"`

--- a/cmd/module_create.go
+++ b/cmd/module_create.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"terrakube/client/models"
 	"fmt"
+	"terrakube/client/models"
 
 	"github.com/spf13/cobra"
 )
@@ -15,6 +15,8 @@ var ModuleCreateDescription string
 var ModuleCreateOrgId string
 var ModuleCreateSource string
 var ModuleCreateProvider string
+var ModuleCreateTagPrefix string
+var ModuleCreateFolder string
 
 var createModuleCmd = &cobra.Command{
 	Use:   "create",
@@ -34,6 +36,8 @@ func init() {
 	createModuleCmd.Flags().StringVarP(&ModuleCreateDescription, "description", "d", "", "Description of the new module")
 	createModuleCmd.Flags().StringVarP(&ModuleCreateSource, "source", "s", "", "Source of the new module")
 	createModuleCmd.Flags().StringVarP(&ModuleCreateProvider, "provider", "p", "", "Provider of the new module")
+	createModuleCmd.Flags().StringVarP(&ModuleCreateTagPrefix, "tag-prefix", "t", "", "Tag prefix of the new module")
+	createModuleCmd.Flags().StringVarP(&ModuleCreateFolder, "folder", "f", "", "Folder of the new module")
 
 }
 
@@ -42,11 +46,12 @@ func createModule() {
 
 	module := models.Module{
 		Attributes: &models.ModuleAttributes{
-			Description:  ModuleCreateDescription,
-			Name:         ModuleCreateName,
-			Source:       ModuleCreateSource,
-			SourceSample: ModuleCreateSource,
-			Provider:     ModuleCreateProvider,
+			Description: ModuleCreateDescription,
+			Name:        ModuleCreateName,
+			Source:      ModuleCreateSource,
+			Provider:    ModuleCreateProvider,
+			TagPrefix:   &ModuleCreateTagPrefix,
+			Folder:      &ModuleCreateFolder,
 		},
 		Type: "module",
 	}

--- a/cmd/module_update.go
+++ b/cmd/module_update.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"terrakube/client/models"
 	"fmt"
+	"terrakube/client/models"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +16,8 @@ var ModuleUpdateName string
 var ModuleUpdateOrgId string
 var ModuleUpdateSource string
 var ModuleUpdateProvider string
+var ModuleUpdateTagPrefix string
+var ModuleUpdateFolder string
 
 var updateModuleCmd = &cobra.Command{
 	Use:   "update",
@@ -31,12 +33,14 @@ func init() {
 	updateModuleCmd.AddCommand(updateOrganizationCmd)
 	updateModuleCmd.Flags().StringVarP(&ModuleId, "id", "", "", "Id of the module (required)")
 	_ = updateModuleCmd.MarkFlagRequired("id")
-	updateModuleCmd.Flags().StringVarP(&ModuleUpdateName, "name", "n", "", "Name of the module")
-	updateModuleCmd.Flags().StringVarP(&ModuleUpdateDescription, "description", "d", "", "Description of the module")
 	updateModuleCmd.Flags().StringVarP(&ModuleUpdateOrgId, "organization-id", "", "", "Organization Id (required)")
 	_ = updateModuleCmd.MarkFlagRequired("organization-id")
+	updateModuleCmd.Flags().StringVarP(&ModuleUpdateName, "name", "n", "", "Name of the module")
+	updateModuleCmd.Flags().StringVarP(&ModuleUpdateDescription, "description", "d", "", "Description of the module")
 	updateModuleCmd.Flags().StringVarP(&ModuleUpdateSource, "source", "s", "", "Source of the module")
 	updateModuleCmd.Flags().StringVarP(&ModuleUpdateProvider, "provider", "p", "", "Provider of the module")
+	updateModuleCmd.Flags().StringVarP(&ModuleUpdateTagPrefix, "tag-prefix", "t", "", "Tag prefix of the module")
+	updateModuleCmd.Flags().StringVarP(&ModuleUpdateFolder, "folder", "f", "", "Folder of the module")
 }
 
 func updateModule() {
@@ -48,6 +52,8 @@ func updateModule() {
 			Description: ModuleUpdateDescription,
 			Source:      ModuleUpdateSource,
 			Provider:    ModuleUpdateProvider,
+			TagPrefix:   &ModuleUpdateTagPrefix,
+			Folder:      &ModuleUpdateFolder,
 		},
 		ID:   ModuleId,
 		Type: "module",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,6 +149,21 @@ func splitInterface(input interface{}) ([][]string, []string) {
 				switch fieldValue.Kind() {
 				case reflect.Bool:
 					valueStr = fmt.Sprintf("%t", fieldValue.Bool())
+				case reflect.Ptr:
+					if fieldValue.IsNil() {
+						valueStr = ""
+					} else {
+						// Dereference the pointer and get its value
+						derefValue := fieldValue.Elem()
+						switch derefValue.Kind() {
+						case reflect.String:
+							valueStr = derefValue.String()
+						case reflect.Bool:
+							valueStr = fmt.Sprintf("%t", derefValue.Bool())
+						default:
+							valueStr = fmt.Sprintf("%v", derefValue.Interface())
+						}
+					}
 				default:
 					valueStr = fieldValue.String()
 				}
@@ -171,6 +186,22 @@ func splitInterface(input interface{}) ([][]string, []string) {
 			switch fieldValue.Kind() {
 			case reflect.Bool:
 				valueStr = fmt.Sprintf("%t", fieldValue.Bool())
+			case reflect.Ptr:
+				if fieldValue.IsNil() {
+					valueStr = ""
+				} else {
+					// Dereference the pointer and get its value
+					derefValue := fieldValue.Elem()
+					switch derefValue.Kind() {
+					case reflect.String:
+						valueStr = derefValue.String()
+
+					case reflect.Bool:
+						valueStr = fmt.Sprintf("%t", derefValue.Bool())
+					default:
+						valueStr = fmt.Sprintf("%v", derefValue.Interface())
+					}
+				}
 			default:
 				valueStr = fieldValue.String()
 			}

--- a/cmd/team_update.go
+++ b/cmd/team_update.go
@@ -16,6 +16,10 @@ var TeamUpdateOrgId string
 var TeamUpdateManageProvider bool
 var TeamUpdateManageModule bool
 var TeamUpdateManageWorkspace bool
+var TeamUpdateManageState bool
+var TeamUpdateManageCollection bool
+var TeamUpdateManageVcs bool
+var TeamUpdateManageTemplate bool
 
 var updateTeamCmd = &cobra.Command{
 	Use:   "update",
@@ -37,7 +41,10 @@ func init() {
 	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageProvider, "manage-provider", "", false, "Manage Provider Permissions")
 	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageModule, "manage-module", "", false, "Manage Module Permissions")
 	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageWorkspace, "manage-workspace", "", false, "Manage Workspaces Permissions")
-
+	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageState, "manage-state", "", false, "Manage State Permissions")
+	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageCollection, "manage-collection", "", false, "Manage Collection Permissions")
+	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageVcs, "manage-vcs", "", false, "Manage VCS Permissions")
+	updateTeamCmd.Flags().BoolVarP(&TeamUpdateManageTemplate, "manage-template", "", false, "Manage Template Permissions")
 }
 
 func updateTeam() {
@@ -45,10 +52,14 @@ func updateTeam() {
 
 	team := models.Team{
 		Attributes: &models.TeamAttributes{
-			Name:            TeamUpdateName,
-			ManageWorkspace: TeamUpdateManageWorkspace,
-			ManageModule:    TeamUpdateManageModule,
-			ManageProvider:  TeamUpdateManageProvider,
+			Name:             TeamUpdateName,
+			ManageWorkspace:  TeamUpdateManageWorkspace,
+			ManageModule:     TeamUpdateManageModule,
+			ManageProvider:   TeamUpdateManageProvider,
+			ManageState:      TeamUpdateManageState,
+			ManageCollection: TeamUpdateManageCollection,
+			ManageVcs:        TeamUpdateManageVcs,
+			ManageTemplate:   TeamUpdateManageTemplate,
 		},
 		ID:   TeamId,
 		Type: "Team",


### PR DESCRIPTION
- Added `TagPrefix` and `Folder` attributes for module creation and updates.
- Introduced new team permissions: `ManageState`, `ManageCollection`, `ManageVcs`, and `ManageTemplate`.
- Enhanced CLI flag handling and updated module model to handle nullable fields.